### PR TITLE
Improve `dotnetup` Muxer Handling, In-Use Muxer + Perf

### DIFF
--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetArchiveExtractor.cs
@@ -103,7 +103,7 @@ internal class DotnetArchiveExtractor : IDisposable
         Directory.CreateDirectory(targetDir);
 
         // Set up muxer handling - muxer will be extracted to temp path during main extraction
-        var muxerHandler = new MuxerHandler(targetDir);
+        var muxerHandler = new MuxerHandler(targetDir, _request.Options.RequireMuxerUpdate);
         muxerHandler.RecordPreExtractionState();
 
         // Extract everything, redirecting muxer to temp path

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetInstall.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/DotnetInstall.cs
@@ -29,4 +29,10 @@ internal record InstallRequestOptions()
 {
     // Include options such as the custom feed, manifest path, etc.
     public string? ManifestPath { get; init; }
+
+    /// <summary>
+    /// If true, the installation will fail if the muxer (dotnet executable) cannot be updated.
+    /// If false (default), a warning is displayed but installation continues.
+    /// </summary>
+    public bool RequireMuxerUpdate { get; init; }
 }

--- a/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
+++ b/src/Installer/Microsoft.Dotnet.Installation/Internal/MuxerHandler.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Dotnet.Installation.Internal;
+
+/// <summary>
+/// Handles muxer (dotnet executable) replacement logic during archive extraction.
+/// The muxer should only be replaced when installing a newer core runtime version.
+/// 
+/// Workflow:
+/// 1. Before extraction: record the highest existing runtime version
+/// 2. Extract everything, but redirect the muxer to a temp file
+/// 3. After extraction: check if a higher runtime version now exists
+/// 4. If yes, move the temp muxer to the real location; otherwise delete it
+/// </summary>
+internal class MuxerHandler
+{
+    private readonly string _targetDir;
+    private readonly string _muxerName;
+    private readonly string _muxerTargetPath;
+    private readonly string _tempMuxerPath;
+    private readonly string _existingMuxerBackupPath;
+
+    private Version? _preExtractionHighestRuntimeVersion;
+    private bool _hadExistingMuxer;
+    private bool _extractedNewMuxer;
+    private bool _movedExistingMuxer;
+
+    public MuxerHandler(string targetDir)
+    {
+        _targetDir = targetDir;
+        _muxerName = DotnetupUtilities.GetDotnetExeName();
+        _muxerTargetPath = Path.Combine(targetDir, _muxerName);
+        _tempMuxerPath = $"{_muxerTargetPath}.{Guid.NewGuid()}.new";
+        _existingMuxerBackupPath = $"{_muxerTargetPath}.{Guid.NewGuid()}.old";
+    }
+
+    /// <summary>
+    /// Gets the muxer entry name to detect during extraction.
+    /// </summary>
+    public string MuxerEntryName => _muxerName;
+
+    /// <summary>
+    /// Gets the path where the muxer should be extracted to during the main extraction pass.
+    /// This is a temp path - the muxer will be moved to its final location after extraction.
+    /// </summary>
+    public string TempMuxerPath => _tempMuxerPath;
+
+    /// <summary>
+    /// Records the state before extraction begins.
+    /// Call this before extracting the archive.
+    /// </summary>
+    public void RecordPreExtractionState()
+    {
+        _preExtractionHighestRuntimeVersion = GetLatestRuntimeVersionFromInstallRoot(_targetDir);
+        _hadExistingMuxer = File.Exists(_muxerTargetPath);
+    }
+
+    /// <summary>
+    /// Called by the extractor when the muxer entry is being extracted.
+    /// Returns the path where the muxer should be written.
+    /// </summary>
+    public string GetMuxerExtractionPath()
+    {
+        _extractedNewMuxer = true;
+        return _tempMuxerPath;
+    }
+
+    /// <summary>
+    /// After extraction completes, determines if the muxer should be updated
+    /// and moves/deletes the temp muxer accordingly.
+    /// </summary>
+    public void FinalizeAfterExtraction()
+    {
+        // If no muxer was extracted (e.g., WindowsDesktop), nothing to do
+        if (!_extractedNewMuxer || !File.Exists(_tempMuxerPath))
+        {
+            return;
+        }
+
+        var postExtractionHighestRuntimeVersion = GetLatestRuntimeVersionFromInstallRoot(_targetDir);
+
+        // If no runtime exists after extraction, something is wrong - but keep the muxer
+        if (postExtractionHighestRuntimeVersion == null)
+        {
+            // Clean up temp file since we can't determine what to do
+            TryDeleteTempMuxer();
+            return;
+        }
+
+        // Determine if we should update the muxer
+        bool shouldUpdateMuxer;
+        if (_preExtractionHighestRuntimeVersion == null)
+        {
+            // No runtime existed before - we need the muxer
+            shouldUpdateMuxer = true;
+        }
+        else if (postExtractionHighestRuntimeVersion > _preExtractionHighestRuntimeVersion)
+        {
+            // A higher runtime version was installed - update the muxer
+            shouldUpdateMuxer = true;
+        }
+        else
+        {
+            // Existing runtime is same or higher - keep existing muxer
+            shouldUpdateMuxer = false;
+        }
+
+        if (!shouldUpdateMuxer)
+        {
+            TryDeleteTempMuxer();
+            return;
+        }
+
+        // Move the existing muxer out of the way if it exists
+        if (_hadExistingMuxer)
+        {
+            try
+            {
+                File.Move(_muxerTargetPath, _existingMuxerBackupPath);
+                _movedExistingMuxer = true;
+            }
+            catch (Exception ex) when (IsFileInUseException(ex))
+            {
+                Console.WriteLine($"Warning: Could not update dotnet executable - it is currently in use by another process. " +
+                    $"The existing muxer will be retained. This may cause issues if the new runtime requires a newer muxer.");
+                TryDeleteTempMuxer();
+                return;
+            }
+        }
+
+        try
+        {
+            // Move the new muxer into place
+            File.Move(_tempMuxerPath, _muxerTargetPath);
+
+            // Clean up the backup
+            if (_movedExistingMuxer && File.Exists(_existingMuxerBackupPath))
+            {
+                try { File.Delete(_existingMuxerBackupPath); } catch { }
+            }
+        }
+        catch
+        {
+            // Restore the original muxer if we moved it
+            if (_movedExistingMuxer && File.Exists(_existingMuxerBackupPath) && !File.Exists(_muxerTargetPath))
+            {
+                try { File.Move(_existingMuxerBackupPath, _muxerTargetPath); } catch { }
+            }
+            throw;
+        }
+    }
+
+    private void TryDeleteTempMuxer()
+    {
+        if (File.Exists(_tempMuxerPath))
+        {
+            try { File.Delete(_tempMuxerPath); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Gets the latest runtime version from the install root by checking the shared/Microsoft.NETCore.App directory.
+    /// </summary>
+    private static Version? GetLatestRuntimeVersionFromInstallRoot(string installRoot)
+    {
+        var runtimePath = Path.Combine(installRoot, "shared", "Microsoft.NETCore.App");
+        if (!Directory.Exists(runtimePath))
+        {
+            return null;
+        }
+
+        Version? highestVersion = null;
+        foreach (var dir in Directory.GetDirectories(runtimePath))
+        {
+            var versionString = Path.GetFileName(dir);
+            if (Version.TryParse(versionString, out Version? dirVersion))
+            {
+                if (highestVersion == null || dirVersion > highestVersion)
+                {
+                    highestVersion = dirVersion;
+                }
+            }
+        }
+
+        return highestVersion;
+    }
+
+    private static bool IsFileInUseException(Exception ex)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return ex is UnauthorizedAccessException || ex is IOException;
+        }
+        return false;
+    }
+}

--- a/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
+++ b/src/Installer/Microsoft.Dotnet.Installation/Microsoft.Dotnet.Installation.csproj
@@ -23,5 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" />
+    <PackageReference Include="Spectre.Console" />
   </ItemGroup>
 </Project>

--- a/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommand.cs
+++ b/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommand.cs
@@ -16,6 +16,7 @@ internal class RuntimeInstallCommand(ParseResult result) : CommandBase(result)
     private readonly string? _manifestPath = result.GetValue(RuntimeInstallCommandParser.ManifestPathOption);
     private readonly bool _interactive = result.GetValue(RuntimeInstallCommandParser.InteractiveOption);
     private readonly bool _noProgress = result.GetValue(RuntimeInstallCommandParser.NoProgressOption);
+    private readonly bool _requireMuxerUpdate = result.GetValue(RuntimeInstallCommandParser.RequireMuxerUpdateOption);
 
     private readonly IDotnetInstallManager _dotnetInstaller = new DotnetInstallManager();
     private readonly ChannelVersionResolver _channelVersionResolver = new ChannelVersionResolver();
@@ -64,7 +65,8 @@ internal class RuntimeInstallCommand(ParseResult result) : CommandBase(result)
             _interactive,
             _noProgress,
             runtimeInfo.Component,
-            runtimeInfo.Description);
+            runtimeInfo.Description,
+            RequireMuxerUpdate: _requireMuxerUpdate);
 
         InstallWorkflow.InstallWorkflowResult workflowResult = workflow.Execute(options);
         return workflowResult.ExitCode;

--- a/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommandParser.cs
+++ b/src/Installer/dotnetup/Commands/Runtime/Install/RuntimeInstallCommandParser.cs
@@ -34,6 +34,7 @@ internal static class RuntimeInstallCommandParser
     public static readonly Option<string> ManifestPathOption = CommonOptions.ManifestPathOption;
     public static readonly Option<bool> InteractiveOption = CommonOptions.InteractiveOption;
     public static readonly Option<bool> NoProgressOption = CommonOptions.NoProgressOption;
+    public static readonly Option<bool> RequireMuxerUpdateOption = CommonOptions.RequireMuxerUpdateOption;
 
     private static readonly Command RuntimeInstallCommand = ConstructCommand();
 
@@ -55,6 +56,7 @@ internal static class RuntimeInstallCommandParser
 
         command.Options.Add(InteractiveOption);
         command.Options.Add(NoProgressOption);
+        command.Options.Add(RequireMuxerUpdateOption);
 
         command.SetAction(parseResult => new RuntimeInstallCommand(parseResult).Execute());
 

--- a/src/Installer/dotnetup/Commands/Sdk/Install/SdkInstallCommand.cs
+++ b/src/Installer/dotnetup/Commands/Sdk/Install/SdkInstallCommand.cs
@@ -17,6 +17,7 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
     private readonly string? _manifestPath = result.GetValue(SdkInstallCommandParser.ManifestPathOption);
     private readonly bool _interactive = result.GetValue(SdkInstallCommandParser.InteractiveOption);
     private readonly bool _noProgress = result.GetValue(SdkInstallCommandParser.NoProgressOption);
+    private readonly bool _requireMuxerUpdate = result.GetValue(SdkInstallCommandParser.RequireMuxerUpdateOption);
 
     private readonly IDotnetInstallManager _dotnetInstaller = new DotnetInstallManager();
     private readonly ChannelVersionResolver _channelVersionResolver = new ChannelVersionResolver();
@@ -35,7 +36,8 @@ internal class SdkInstallCommand(ParseResult result) : CommandBase(result)
             InstallComponent.SDK,
             ".NET SDK",
             _updateGlobalJson,
-            ResolveChannelFromGlobalJson);
+            ResolveChannelFromGlobalJson,
+            _requireMuxerUpdate);
 
         var result = workflow.Execute(options);
         return result.ExitCode;

--- a/src/Installer/dotnetup/Commands/Sdk/Install/SdkInstallCommandParser.cs
+++ b/src/Installer/dotnetup/Commands/Sdk/Install/SdkInstallCommandParser.cs
@@ -19,6 +19,7 @@ internal static class SdkInstallCommandParser
     public static readonly Option<string> ManifestPathOption = CommonOptions.ManifestPathOption;
     public static readonly Option<bool> InteractiveOption = CommonOptions.InteractiveOption;
     public static readonly Option<bool> NoProgressOption = CommonOptions.NoProgressOption;
+    public static readonly Option<bool> RequireMuxerUpdateOption = CommonOptions.RequireMuxerUpdateOption;
 
     public static readonly Option<bool?> UpdateGlobalJsonOption = new("--update-global-json")
     {
@@ -57,6 +58,7 @@ internal static class SdkInstallCommandParser
 
         command.Options.Add(InteractiveOption);
         command.Options.Add(NoProgressOption);
+        command.Options.Add(RequireMuxerUpdateOption);
 
         command.SetAction(parseResult => new SdkInstallCommand(parseResult).Execute());
 

--- a/src/Installer/dotnetup/Commands/Shared/InstallExecutor.cs
+++ b/src/Installer/dotnetup/Commands/Shared/InstallExecutor.cs
@@ -30,13 +30,15 @@ internal class InstallExecutor
     /// <param name="component">The component type (SDK, Runtime, ASPNETCore, WindowsDesktop).</param>
     /// <param name="manifestPath">Optional manifest path for tracking installations.</param>
     /// <param name="channelVersionResolver">The resolver to use for version resolution.</param>
+    /// <param name="requireMuxerUpdate">If true, fail when the muxer cannot be updated.</param>
     /// <returns>The resolved install request with version information.</returns>
     public static ResolvedInstallRequest CreateAndResolveRequest(
         string installPath,
         string channel,
         InstallComponent component,
         string? manifestPath,
-        ChannelVersionResolver channelVersionResolver)
+        ChannelVersionResolver channelVersionResolver,
+        bool requireMuxerUpdate = false)
     {
         var installRoot = new DotnetInstallRoot(installPath, InstallerUtilities.GetDefaultInstallArchitecture());
 
@@ -46,7 +48,8 @@ internal class InstallExecutor
             component,
             new InstallRequestOptions
             {
-                ManifestPath = manifestPath
+                ManifestPath = manifestPath,
+                RequireMuxerUpdate = requireMuxerUpdate
             });
 
         var resolvedVersion = channelVersionResolver.Resolve(request);
@@ -90,6 +93,7 @@ internal class InstallExecutor
     /// <param name="componentDescription">Description of the component for display.</param>
     /// <param name="manifestPath">Optional manifest path.</param>
     /// <param name="noProgress">Whether to suppress progress display.</param>
+    /// <param name="requireMuxerUpdate">If true, fail when the muxer cannot be updated.</param>
     /// <returns>True if all installations succeeded, false if any failed.</returns>
     public static bool ExecuteAdditionalInstalls(
         IEnumerable<string> additionalVersions,
@@ -97,7 +101,8 @@ internal class InstallExecutor
         InstallComponent component,
         string componentDescription,
         string? manifestPath,
-        bool noProgress)
+        bool noProgress,
+        bool requireMuxerUpdate = false)
     {
         bool allSucceeded = true;
 
@@ -109,7 +114,8 @@ internal class InstallExecutor
                 component,
                 new InstallRequestOptions
                 {
-                    ManifestPath = manifestPath
+                    ManifestPath = manifestPath,
+                    RequireMuxerUpdate = requireMuxerUpdate
                 });
 
             var additionalInstall = InstallerOrchestratorSingleton.Instance.Install(additionalRequest, noProgress);

--- a/src/Installer/dotnetup/Commands/Shared/InstallWorkflow.cs
+++ b/src/Installer/dotnetup/Commands/Shared/InstallWorkflow.cs
@@ -31,7 +31,8 @@ internal class InstallWorkflow
         InstallComponent Component,
         string ComponentDescription,
         bool? UpdateGlobalJson = null,
-        Func<string, string?>? ResolveChannelFromGlobalJson = null);
+        Func<string, string?>? ResolveChannelFromGlobalJson = null,
+        bool RequireMuxerUpdate = false);
 
     public record InstallWorkflowResult(int ExitCode, InstallExecutor.ResolvedInstallRequest? ResolvedRequest);
 
@@ -125,7 +126,8 @@ internal class InstallWorkflow
             context.Channel,
             context.Options.Component,
             context.Options.ManifestPath,
-            _channelVersionResolver);
+            _channelVersionResolver,
+            context.Options.RequireMuxerUpdate);
     }
 
     private bool ExecuteInstallations(WorkflowContext context, InstallExecutor.ResolvedInstallRequest resolved)
@@ -152,7 +154,8 @@ internal class InstallWorkflow
             context.Options.Component,
             context.Options.ComponentDescription,
             context.Options.ManifestPath,
-            context.Options.NoProgress);
+            context.Options.NoProgress,
+            context.Options.RequireMuxerUpdate);
 
         return true;
     }

--- a/src/Installer/dotnetup/CommonOptions.cs
+++ b/src/Installer/dotnetup/CommonOptions.cs
@@ -42,6 +42,12 @@ internal class CommonOptions
         Description = "Custom path to the manifest file for tracking .NET installations",
     };
 
+    public static Option<bool> RequireMuxerUpdateOption = new("--require-muxer-update")
+    {
+        Description = "Fail if the muxer (dotnet executable) cannot be updated. By default, a warning is displayed but installation continues.",
+        Arity = ArgumentArity.ZeroOrOne
+    };
+
     private static bool IsCIEnvironmentOrRedirected() =>
         new Cli.Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment() || Console.IsOutputRedirected;
 }

--- a/test/dotnetup.Tests/MuxerHandlerTests.cs
+++ b/test/dotnetup.Tests/MuxerHandlerTests.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.Dotnet.Installation.Internal;
+using Xunit;
+
+namespace Microsoft.Dotnet.Installation.Tests;
+
+public class MuxerHandlerTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly string _muxerPath;
+    private readonly MuxerHandler _handler;
+
+    public MuxerHandlerTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"muxer-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testDir);
+        _muxerPath = Path.Combine(_testDir, DotnetupUtilities.GetDotnetExeName());
+        _handler = new MuxerHandler(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir))
+        {
+            Directory.Delete(_testDir, recursive: true);
+        }
+    }
+
+    private void CreateRuntime(string version)
+    {
+        var runtimeDir = Path.Combine(_testDir, "shared", "Microsoft.NETCore.App", version);
+        Directory.CreateDirectory(runtimeDir);
+        File.WriteAllText(Path.Combine(runtimeDir, "marker.txt"), "test");
+    }
+
+    private void CreateExistingMuxer(string content = "existing")
+    {
+        File.WriteAllText(_muxerPath, content);
+    }
+
+    /// <summary>
+    /// Simulates what the archive extractor does: calls GetMuxerExtractionPath() when 
+    /// it encounters the muxer entry, then writes to that path.
+    /// </summary>
+    private void SimulateMuxerExtraction(string content = "new")
+    {
+        var tempPath = _handler.GetMuxerExtractionPath();
+        File.WriteAllText(tempPath, content);
+    }
+
+    [Fact]
+    public void NoExistingMuxer_ExtractsNewMuxer()
+    {
+        // Arrange
+        _handler.RecordPreExtractionState();
+        CreateRuntime("8.0.0");
+        SimulateMuxerExtraction("new-8.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert
+        File.Exists(_muxerPath).Should().BeTrue();
+        File.ReadAllText(_muxerPath).Should().Be("new-8.0");
+        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExistingMuxer_NewerRuntime_ReplacesMuxer()
+    {
+        // Arrange
+        CreateRuntime("7.0.0");
+        CreateExistingMuxer("old-7.0");
+        _handler.RecordPreExtractionState();
+        CreateRuntime("8.0.0");
+        SimulateMuxerExtraction("new-8.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert
+        File.ReadAllText(_muxerPath).Should().Be("new-8.0");
+        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExistingMuxer_SameOrOlderRuntime_KeepsExisting()
+    {
+        // Arrange
+        CreateRuntime("8.0.0");
+        CreateExistingMuxer("existing-8.0");
+        _handler.RecordPreExtractionState();
+        CreateRuntime("7.0.0"); // Older runtime
+        SimulateMuxerExtraction("new-7.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - existing muxer unchanged, temp deleted
+        File.ReadAllText(_muxerPath).Should().Be("existing-8.0");
+        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NoRuntimeExtracted_DeletesTempMuxer()
+    {
+        // Arrange - simulates WindowsDesktop which has no core runtime
+        CreateExistingMuxer("existing");
+        _handler.RecordPreExtractionState();
+        // Muxer extracted but no runtime created
+        SimulateMuxerExtraction("new");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - existing muxer unchanged, temp deleted
+        File.ReadAllText(_muxerPath).Should().Be("existing");
+        File.Exists(_handler.TempMuxerPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NoTempMuxerExtracted_NoOp()
+    {
+        // Arrange - archive didn't contain a muxer (GetMuxerExtractionPath never called)
+        CreateRuntime("8.0.0");
+        CreateExistingMuxer("existing");
+        _handler.RecordPreExtractionState();
+        CreateRuntime("9.0.0"); // New runtime but muxer not extracted
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - existing muxer unchanged
+        File.ReadAllText(_muxerPath).Should().Be("existing");
+    }
+
+    [Fact]
+    public void MultipleRuntimes_UsesHighestForComparison()
+    {
+        // Arrange - multiple existing runtimes, highest is 8.0.0
+        CreateRuntime("6.0.0");
+        CreateRuntime("7.0.0");
+        CreateRuntime("8.0.0");
+        CreateExistingMuxer("existing-8.0");
+        _handler.RecordPreExtractionState();
+        
+        // Install 9.0.0 (higher than existing highest)
+        CreateRuntime("9.0.0");
+        SimulateMuxerExtraction("new-9.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - should replace since 9.0.0 > 8.0.0
+        File.ReadAllText(_muxerPath).Should().Be("new-9.0");
+    }
+
+    [Fact]
+    public void NoPreExistingRuntime_ExtractsMuxer()
+    {
+        // Edge case: no runtime directories exist yet
+        _handler.RecordPreExtractionState();
+        CreateRuntime("8.0.0");
+        SimulateMuxerExtraction("new-8.0");
+
+        // Act
+        _handler.FinalizeAfterExtraction();
+
+        // Assert - should install new muxer
+        File.ReadAllText(_muxerPath).Should().Be("new-8.0");
+    }
+}


### PR DESCRIPTION
When moving the .NET SDK build to use `dotnetup` in https://github.com/nagilson/sdk/pull/8, I hit several issues. The main issue is that the dotnet muxer may be in use when dotnetup tries to replace it, which would cause a failure.

I don't think we want to fail in this case and instead we want to emit a warning. I've added an option to fail instead, however.

What I also realized is that the approach of renaming the muxer even if it doesn't need to be replaced would cause the warning message to appear even if we didn't need to replace the muxer.  Then I realized, we can do something clever. The windowsdesktop runtime has no runtime so we can skip muxer logic there. The other runtimes versions are the deciding factor for the muxer version since the muxer doesn't have its own version, so we can skip the resolution to find the version there. For the SDK, what we can do to avoid an extra rename of the existing muxer if it doesn't need to be replaced, is to extract out the new muxer to a different name temporarily, and then look and see if the latest runtime in the dotnet install root target changed after that install. If so then the runtime that came with  the SDK is newer so the new muxer should be used. This lets us gracefully handle when  the muxer is in use as well as avoid any extra work we don't need to do.